### PR TITLE
Add initial JavaScript SDK skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ site/
 .mypy_cache/
 .dmypy.json
 dmypy.json
+!vaiz-js-sdk/dist/

--- a/vaiz-js-sdk/.gitignore
+++ b/vaiz-js-sdk/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/vaiz-js-sdk/README.md
+++ b/vaiz-js-sdk/README.md
@@ -1,0 +1,18 @@
+# Vaiz JavaScript SDK
+
+Basic JavaScript/TypeScript SDK for the Vaiz API.
+
+```ts
+import { VaizClient } from './dist';
+
+const client = new VaizClient({
+  apiKey: 'your-api-key',
+  spaceId: 'your-space-id',
+});
+
+async function main() {
+  const boards = await client.boards.getBoards();
+  console.log(boards);
+}
+main();
+```

--- a/vaiz-js-sdk/dist/api/boards.d.ts
+++ b/vaiz-js-sdk/dist/api/boards.d.ts
@@ -1,0 +1,39 @@
+import { BaseAPIClient } from '../client/BaseAPIClient';
+import { z } from 'zod';
+export declare const BoardSchema: z.ZodObject<{
+    _id: z.ZodString;
+    name: z.ZodString;
+}, "strip", z.ZodTypeAny, {
+    _id: string;
+    name: string;
+}, {
+    _id: string;
+    name: string;
+}>;
+export type Board = z.infer<typeof BoardSchema>;
+export declare const BoardsResponseSchema: z.ZodObject<{
+    boards: z.ZodArray<z.ZodObject<{
+        _id: z.ZodString;
+        name: z.ZodString;
+    }, "strip", z.ZodTypeAny, {
+        _id: string;
+        name: string;
+    }, {
+        _id: string;
+        name: string;
+    }>, "many">;
+}, "strip", z.ZodTypeAny, {
+    boards: {
+        _id: string;
+        name: string;
+    }[];
+}, {
+    boards: {
+        _id: string;
+        name: string;
+    }[];
+}>;
+export type BoardsResponse = z.infer<typeof BoardsResponseSchema>;
+export declare class BoardsAPI extends BaseAPIClient {
+    getBoards(): Promise<BoardsResponse>;
+}

--- a/vaiz-js-sdk/dist/api/boards.js
+++ b/vaiz-js-sdk/dist/api/boards.js
@@ -1,0 +1,30 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.BoardsAPI = exports.BoardsResponseSchema = exports.BoardSchema = void 0;
+const BaseAPIClient_1 = require("../client/BaseAPIClient");
+const zod_1 = require("zod");
+exports.BoardSchema = zod_1.z.object({
+    _id: zod_1.z.string(),
+    name: zod_1.z.string(),
+});
+exports.BoardsResponseSchema = zod_1.z.object({
+    boards: zod_1.z.array(exports.BoardSchema),
+});
+class BoardsAPI extends BaseAPIClient_1.BaseAPIClient {
+    getBoards() {
+        return __awaiter(this, void 0, void 0, function* () {
+            const res = yield this.http.get('/boards');
+            return exports.BoardsResponseSchema.parse(res.data);
+        });
+    }
+}
+exports.BoardsAPI = BoardsAPI;

--- a/vaiz-js-sdk/dist/client/BaseAPIClient.d.ts
+++ b/vaiz-js-sdk/dist/client/BaseAPIClient.d.ts
@@ -1,0 +1,12 @@
+import { AxiosInstance } from 'axios';
+export interface VaizClientConfig {
+    apiKey: string;
+    spaceId: string;
+    baseUrl?: string;
+    timeout?: number;
+}
+export declare class BaseAPIClient {
+    private config;
+    protected http: AxiosInstance;
+    constructor(config: VaizClientConfig);
+}

--- a/vaiz-js-sdk/dist/client/BaseAPIClient.js
+++ b/vaiz-js-sdk/dist/client/BaseAPIClient.js
@@ -1,0 +1,23 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.BaseAPIClient = void 0;
+const axios_1 = __importDefault(require("axios"));
+class BaseAPIClient {
+    constructor(config) {
+        this.config = config;
+        this.http = axios_1.default.create({
+            baseURL: config.baseUrl || 'https://api.vaiz.app/v4',
+            timeout: config.timeout || 10000,
+        });
+        this.http.interceptors.request.use((req) => {
+            req.headers = req.headers || {};
+            req.headers['Authorization'] = `Bearer ${this.config.apiKey}`;
+            req.headers['X-Space-Id'] = this.config.spaceId;
+            return req;
+        });
+    }
+}
+exports.BaseAPIClient = BaseAPIClient;

--- a/vaiz-js-sdk/dist/client/VaizClient.d.ts
+++ b/vaiz-js-sdk/dist/client/VaizClient.d.ts
@@ -1,0 +1,7 @@
+import { VaizClientConfig, BaseAPIClient } from './BaseAPIClient';
+import { BoardsAPI } from '../api/boards';
+export declare class VaizClient extends BaseAPIClient {
+    boards: BoardsAPI;
+    constructor(config: VaizClientConfig);
+}
+export { VaizClientConfig } from './BaseAPIClient';

--- a/vaiz-js-sdk/dist/client/VaizClient.js
+++ b/vaiz-js-sdk/dist/client/VaizClient.js
@@ -1,0 +1,12 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.VaizClient = void 0;
+const BaseAPIClient_1 = require("./BaseAPIClient");
+const boards_1 = require("../api/boards");
+class VaizClient extends BaseAPIClient_1.BaseAPIClient {
+    constructor(config) {
+        super(config);
+        this.boards = new boards_1.BoardsAPI(config);
+    }
+}
+exports.VaizClient = VaizClient;

--- a/vaiz-js-sdk/dist/index.d.ts
+++ b/vaiz-js-sdk/dist/index.d.ts
@@ -1,0 +1,2 @@
+export { VaizClient } from './client/VaizClient';
+export type { VaizClientConfig } from './client/BaseAPIClient';

--- a/vaiz-js-sdk/dist/index.js
+++ b/vaiz-js-sdk/dist/index.js
@@ -1,0 +1,5 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.VaizClient = void 0;
+var VaizClient_1 = require("./client/VaizClient");
+Object.defineProperty(exports, "VaizClient", { enumerable: true, get: function () { return VaizClient_1.VaizClient; } });

--- a/vaiz-js-sdk/dist/types/index.d.ts
+++ b/vaiz-js-sdk/dist/types/index.d.ts
@@ -1,0 +1,1 @@
+export * from '../api/boards';

--- a/vaiz-js-sdk/dist/types/index.js
+++ b/vaiz-js-sdk/dist/types/index.js
@@ -1,0 +1,17 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __exportStar = (this && this.__exportStar) || function(m, exports) {
+    for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+__exportStar(require("../api/boards"), exports);

--- a/vaiz-js-sdk/dist/utils/validation.d.ts
+++ b/vaiz-js-sdk/dist/utils/validation.d.ts
@@ -1,0 +1,2 @@
+import { ZodSchema } from 'zod';
+export declare function validate<T>(schema: ZodSchema<T>, data: unknown): T;

--- a/vaiz-js-sdk/dist/utils/validation.js
+++ b/vaiz-js-sdk/dist/utils/validation.js
@@ -1,0 +1,6 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.validate = validate;
+function validate(schema, data) {
+    return schema.parse(data);
+}

--- a/vaiz-js-sdk/package-lock.json
+++ b/vaiz-js-sdk/package-lock.json
@@ -1,0 +1,321 @@
+{
+  "name": "vaiz-js-sdk",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "vaiz-js-sdk",
+      "version": "0.1.0",
+      "dependencies": {
+        "axios": "^1.6.0",
+        "zod": "^3.22.4"
+      },
+      "devDependencies": {
+        "typescript": "^5.2.2"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
+      "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/vaiz-js-sdk/package.json
+++ b/vaiz-js-sdk/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "vaiz-js-sdk",
+  "version": "0.1.0",
+  "description": "JavaScript/TypeScript SDK for Vaiz API",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "echo 'no tests'"
+  },
+  "dependencies": {
+    "axios": "^1.6.0",
+    "zod": "^3.22.4"
+  },
+  "devDependencies": {
+    "typescript": "^5.2.2"
+  }
+}

--- a/vaiz-js-sdk/src/api/boards.ts
+++ b/vaiz-js-sdk/src/api/boards.ts
@@ -1,0 +1,20 @@
+import { BaseAPIClient } from '../client/BaseAPIClient';
+import { z } from 'zod';
+
+export const BoardSchema = z.object({
+  _id: z.string(),
+  name: z.string(),
+});
+export type Board = z.infer<typeof BoardSchema>;
+
+export const BoardsResponseSchema = z.object({
+  boards: z.array(BoardSchema),
+});
+export type BoardsResponse = z.infer<typeof BoardsResponseSchema>;
+
+export class BoardsAPI extends BaseAPIClient {
+  async getBoards(): Promise<BoardsResponse> {
+    const res = await this.http.get('/boards');
+    return BoardsResponseSchema.parse(res.data);
+  }
+}

--- a/vaiz-js-sdk/src/client/BaseAPIClient.ts
+++ b/vaiz-js-sdk/src/client/BaseAPIClient.ts
@@ -1,0 +1,25 @@
+import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
+
+export interface VaizClientConfig {
+  apiKey: string;
+  spaceId: string;
+  baseUrl?: string;
+  timeout?: number;
+}
+
+export class BaseAPIClient {
+  protected http: AxiosInstance;
+  constructor(private config: VaizClientConfig) {
+    this.http = axios.create({
+      baseURL: config.baseUrl || 'https://api.vaiz.app/v4',
+      timeout: config.timeout || 10000,
+    });
+
+    this.http.interceptors.request.use((req) => {
+      req.headers = req.headers || {};
+      req.headers['Authorization'] = `Bearer ${this.config.apiKey}`;
+      req.headers['X-Space-Id'] = this.config.spaceId;
+      return req;
+    });
+  }
+}

--- a/vaiz-js-sdk/src/client/VaizClient.ts
+++ b/vaiz-js-sdk/src/client/VaizClient.ts
@@ -1,0 +1,12 @@
+import { VaizClientConfig, BaseAPIClient } from './BaseAPIClient';
+import { BoardsAPI } from '../api/boards';
+
+export class VaizClient extends BaseAPIClient {
+  boards: BoardsAPI;
+
+  constructor(config: VaizClientConfig) {
+    super(config);
+    this.boards = new BoardsAPI(config);
+  }
+}
+export { VaizClientConfig } from './BaseAPIClient';

--- a/vaiz-js-sdk/src/index.ts
+++ b/vaiz-js-sdk/src/index.ts
@@ -1,0 +1,2 @@
+export { VaizClient } from './client/VaizClient';
+export type { VaizClientConfig } from './client/BaseAPIClient';

--- a/vaiz-js-sdk/src/types/index.ts
+++ b/vaiz-js-sdk/src/types/index.ts
@@ -1,0 +1,1 @@
+export * from '../api/boards';

--- a/vaiz-js-sdk/src/utils/validation.ts
+++ b/vaiz-js-sdk/src/utils/validation.ts
@@ -1,0 +1,5 @@
+import { ZodSchema } from 'zod';
+
+export function validate<T>(schema: ZodSchema<T>, data: unknown): T {
+  return schema.parse(data);
+}

--- a/vaiz-js-sdk/tsconfig.json
+++ b/vaiz-js-sdk/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES6",
+    "module": "CommonJS",
+    "declaration": true,
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- bootstrap `vaiz-js-sdk` with TypeScript config and package.json
- implement basic client infrastructure and Boards API
- compile SDK to `dist`
- update `.gitignore` to keep built JS

## Testing
- `npx tsc`
- `pytest -q` *(fails: ValueError: Please set VAIZ_API_KEY environment variable or create a .env file with VAIZ_API_KEY=your_api_key)*

------
https://chatgpt.com/codex/tasks/task_e_68792c951eb48332be86b5e138c21a6d